### PR TITLE
Bootstrap GitHub Actions workflows on main

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,41 @@
+name: Build Pull Request
+
+# Builds all specifications on pull requests to verify they compile without
+# fatal Bikeshed errors. Mirrors the DASH-IF-IOP build-pr workflow.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'rag-authoring-starter/specs/**'
+      - '.github/workflows/build-pr.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Bikeshed
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install bikeshed
+          bikeshed update
+
+      - name: Install DASH-IF boilerplate (dashif group)
+        working-directory: rag-authoring-starter
+        run: python tools/env/install_dashif_boilerplate.py
+
+      - name: Build all specs (fails on Bikeshed errors)
+        working-directory: rag-authoring-starter
+        run: python tools/publication/build_all.py --out ../dist --die-on warning
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/preview-bikeshed.yml
+++ b/.github/workflows/preview-bikeshed.yml
@@ -1,0 +1,128 @@
+name: Preview Bikeshed Specs
+
+# Manual, unadvertised GitHub Pages preview for editors/reviewers.
+#
+# Official publication remains the Publish Bikeshed Specs workflow from main.
+# This workflow is for temporary publication-style review of a selected branch.
+# It deploys a preview-only Pages artifact containing:
+#   /index.html                         preview landing/warning
+#   /preview.html                       same landing/warning
+#   /previews/<preview-name>/           built specs
+#
+# Important: GitHub Pages has one live deployment per repository. While this
+# preview is active, it replaces the repository's Pages deployment until the main
+# publication workflow is run again. The preview URL is unadvertised and noindex,
+# but it is NOT private.
+
+on:
+  workflow_dispatch:
+    inputs:
+      preview_name:
+        description: 'Preview path name under /previews/ (default: branch name)'
+        required: false
+        type: string
+      noindex:
+        description: 'Add robots noindex/nofollow marker to preview pages'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-preview
+  cancel-in-progress: true
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Bikeshed
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install bikeshed
+          bikeshed update
+
+      - name: Install DASH-IF boilerplate (dashif group)
+        working-directory: rag-authoring-starter
+        run: python tools/env/install_dashif_boilerplate.py
+
+      - name: Build all specs
+        working-directory: rag-authoring-starter
+        run: python tools/publication/build_all.py --out ../site-build
+
+      - name: Prepare preview-only Pages artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          PREVIEW_NAME="${{ inputs.preview_name }}"
+          if [ -z "$PREVIEW_NAME" ]; then
+            PREVIEW_NAME="${GITHUB_REF_NAME}"
+          fi
+          # Conservative URL slug: keep only common safe path characters.
+          PREVIEW_NAME="$(echo "$PREVIEW_NAME" | tr -c 'A-Za-z0-9._-' '-')"
+          PREVIEW_PATH="previews/$PREVIEW_NAME"
+          rm -rf dist
+          mkdir -p "dist/$PREVIEW_PATH"
+          cp -R site-build/. "dist/$PREVIEW_PATH/"
+
+          if [ "${{ inputs.noindex }}" = "true" ]; then
+            printf 'User-agent: *\nDisallow: /\n' > dist/robots.txt
+            find "dist/$PREVIEW_PATH" -name '*.html' -print0 | \
+              xargs -0 sed -i 's#<head>#<head>\n<meta name="robots" content="noindex,nofollow">#'
+          fi
+
+          cat > dist/index.html <<EOF
+          <!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="robots" content="noindex,nofollow">
+            <title>DASH-IF IOP v5 temporary preview</title>
+            <style>
+              body { font-family: system-ui, sans-serif; max-width: 52rem; margin: 2rem auto; padding: 0 1rem; }
+              code { background: #f4f4f4; padding: .1rem .25rem; }
+              .warning { border-left: 4px solid #c70; padding: .75rem 1rem; background: #fff7e6; }
+            </style>
+          </head>
+          <body>
+            <h1>DASH-IF IOP v5 temporary preview</h1>
+            <div class="warning">
+              <p><strong>This is a temporary branch preview, not the official publication.</strong></p>
+              <p>It is unadvertised and marked <code>noindex</code>, but it is not private.</p>
+            </div>
+            <p>Branch/ref: <code>${GITHUB_REF_NAME}</code></p>
+            <p>Preview path: <code>/$PREVIEW_PATH/</code></p>
+            <p><a href="$PREVIEW_PATH/">Open the preview</a></p>
+            <p>Run the main publication workflow again to restore the official Pages deployment.</p>
+          </body>
+          </html>
+          EOF
+          cp dist/index.html dist/preview.html
+          echo "Preview path: /$PREVIEW_PATH/" >> "$GITHUB_STEP_SUMMARY"
+          echo "Preview landing: /preview.html" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy-preview:
+    runs-on: ubuntu-latest
+    needs: build-preview
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}preview.html
+    steps:
+      - name: Deploy preview to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-bikeshed.yml
+++ b/.github/workflows/publish-bikeshed.yml
@@ -1,0 +1,63 @@
+name: Publish Bikeshed Specs
+
+# Publishes the built specifications to GitHub Pages on push to main.
+# Aligned with the DASH-IF-IOP workflow (build -> package -> deploy Pages),
+# but builds with a pip-installed Bikeshed instead of the dashif-specs
+# container, and stages shared boilerplate the same way build.ps1 does.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'rag-authoring-starter/specs/**'
+      - '.github/workflows/publish-bikeshed.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Bikeshed
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install bikeshed
+          bikeshed update
+
+      - name: Install DASH-IF boilerplate (dashif group)
+        working-directory: rag-authoring-starter
+        run: python tools/env/install_dashif_boilerplate.py
+
+      - name: Build all specs
+        working-directory: rag-authoring-starter
+        run: python tools/publication/build_all.py --out ../dist
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,109 @@
-# IOPv5
-IOP v5 editing for tracking issues
+# DASH-IF IOP v5
 
-See Projects for all document parts, titles, editors and issues assigned
+This repository is used for DASH-IF IOP v5 issue tracking and document-authoring
+experiments.
+
+The active Bikeshed/RAG authoring work currently happens on the branch:
+
+```text
+tstockhammer-rag-workflow
+```
+
+The workflow files in this branch are intentionally bootstrapped onto `main` so
+that GitHub shows them in the **Actions** tab. GitHub only lists manually runnable
+workflows after the workflow files exist on the repository's default branch.
+
+## GitHub Actions bootstrap
+
+The following workflows are available once this README/workflow bootstrap is
+merged to `main`:
+
+```text
+.github/workflows/build-pr.yml
+.github/workflows/preview-bikeshed.yml
+.github/workflows/publish-bikeshed.yml
+```
+
+### Preview workflow
+
+Use this for publication-style review of a non-main authoring branch.
+
+1. Go to **Actions**.
+2. Select **Preview Bikeshed Specs**.
+3. Click **Run workflow**.
+4. In the branch selector, choose the branch to preview, for example:
+
+   ```text
+   tstockhammer-rag-workflow
+   ```
+
+5. Optionally set `preview_name`; if omitted, the branch name is used.
+6. Keep `noindex` enabled.
+7. Run the workflow.
+
+Expected preview URL pattern:
+
+```text
+https://dash-industry-forum.github.io/IOPv5/previews/tstockhammer-rag-workflow/
+```
+
+or, for a custom preview name:
+
+```text
+https://dash-industry-forum.github.io/IOPv5/previews/<preview_name>/
+```
+
+A landing page is also generated at:
+
+```text
+https://dash-industry-forum.github.io/IOPv5/preview.html
+```
+
+Important notes:
+
+- The preview is unadvertised and marked `noindex,nofollow`, but it is **not
+  private**.
+- GitHub Pages has one live deployment per repository. A preview deployment may
+  temporarily replace the currently visible Pages deployment until the main
+  publication workflow is run again.
+- Do not use preview deployments for confidential drafts or access-controlled
+  source material.
+
+### Pull-request build workflow
+
+`Build Pull Request` builds all specs for pull requests to `main` and uploads the
+`dist` folder as a workflow artifact. It is mainly useful after the authoring
+branch content is present in the PR.
+
+### Publication workflow
+
+`Publish Bikeshed Specs` is intended to publish the official GitHub Pages site
+from `main` once the Bikeshed authoring content is merged. Until the
+`rag-authoring-starter/` authoring tree is merged to `main`, this workflow is a
+bootstrap placeholder and should not be expected to publish the full site from
+`main`.
+
+For GitHub Pages publication to work, repository administrators need to enable
+GitHub Pages with:
+
+```text
+Source: GitHub Actions
+```
+
+in the repository settings.
+
+## Issue tracking
+
+See Projects for document parts, titles, editors and assigned issues:
+
+```text
 https://github.com/Dash-Industry-Forum/IOPv5/projects
+```
 
-In the issue title please indicate the part # in brackets, e.g. "[9]"; or if able, assign it to a project during creation.
+In issue titles, please indicate the part number in brackets, for example:
+
+```text
+[9] Subtitle profile migration
+```
+
+or assign the issue to the relevant project during creation.


### PR DESCRIPTION
Add only the workflow files needed for GitHub to show Actions on the default branch, plus README instructions for running the temporary preview workflow against the tstockhammer-rag-workflow branch.

This enables Option B: merge a minimal workflow/bootstrap PR first, without merging the full Bikeshed/RAG authoring tree. The README documents preview URLs, noindex/non-private limitations, the one-live-Pages-deployment caveat, and that publication from main requires the authoring tree to be merged later.